### PR TITLE
Add support for action events

### DIFF
--- a/GitHubHook.Tests/AuthenticationTests.cs
+++ b/GitHubHook.Tests/AuthenticationTests.cs
@@ -42,17 +42,15 @@ namespace GitHubHook.Tests
             Assert.IsTrue(result);
         }
 
-        [Ignore("Failing on AppVeyor.")]
         [TestMethod]
         public void GenerateAndCompareSignature_TestSignature2()
         {
             // Arrange
             var resmgr = new InternalResourceManager(typeof(TestPayloadsMarker));
 
+            var secretToken = "A3UB12ga#%TMp%asL5or@Nb2%l8m1h8*vja5^Pj3xc^&%cdYcQo$WNDzfeX*HhUt^SzuDM!g5*RiEEugcb12^u@kh2pdmUtDhaFC";
+            var signature = "sha1=eb4acec0ce7e63f015dfac6681aab94b3ec028ed";
             var payload = resmgr.GetString("PingPayload.json");
-            var payloadSecurity = resmgr.GetString("PingPayloadSecurity.txt").Split(Environment.NewLine);
-            var secretToken = payloadSecurity[0];
-            var signature = payloadSecurity[1];
 
             // Act
             var result = authentication.GenerateAndCompareSignature(secretToken, signature, payload);

--- a/GitHubHook.Tests/EventHandlersRegistryTests.cs
+++ b/GitHubHook.Tests/EventHandlersRegistryTests.cs
@@ -32,7 +32,7 @@ namespace GitHubHook.Tests
         public void RegisterEventHandler_ShouldSucceed()
         {
             // Act
-            eventHandlers.RegisterEventHandler<DefaultHandler>("ping");
+            eventHandlers.RegisterEventHandler<DefaultHandler>();
 
             // Assert
             Assert.AreEqual(1, eventHandlers.eventHandlers.Count);
@@ -42,7 +42,7 @@ namespace GitHubHook.Tests
         public void RegisterEventHandler_WithInstance_ShouldSucceed()
         {
             // Act
-            eventHandlers.RegisterEventHandler("ping", new DefaultHandler());
+            eventHandlers.RegisterEventHandler(new DefaultHandler());
 
             // Assert
             Assert.AreEqual(1, eventHandlers.eventHandlers.Count);
@@ -72,7 +72,7 @@ namespace GitHubHook.Tests
         public void GetEventHandlersOrDefault_ShouldReturnOnlyDefaultHandler_IfEmpty()
         {
             // Act
-            var handlers = eventHandlers.GetEventHandlersOrDefault(Guid.NewGuid().ToString("N"));
+            var handlers = eventHandlers.GetEventHandlersOrDefault(new TestEvent());
 
             // Assert
             Assert.IsNotNull(handlers);
@@ -84,11 +84,10 @@ namespace GitHubHook.Tests
         public void GetEventHandlersOrDefault_ShouldReturnRegisteredHandler_IfAdded()
         {
             // Arrange
-            var eventId = Guid.NewGuid().ToString("N");
-            eventHandlers.RegisterEventHandler<TestHandler>(eventId);
+            eventHandlers.RegisterEventHandler<TestHandler>();
 
             // Act
-            var handlers = eventHandlers.GetEventHandlersOrDefault(eventId);
+            var handlers = eventHandlers.GetEventHandlersOrDefault(new TestEvent());
 
             // Assert
             Assert.IsNotNull(handlers);
@@ -101,11 +100,10 @@ namespace GitHubHook.Tests
         public void GetEventHandlersOrDefault_ShouldReturnRegisteredWildcardHandler_IfAdded()
         {
             // Arrange
-            var eventId = Guid.NewGuid().ToString("N");
             eventHandlers.RegisterWildcardEventHandler<TestHandler>();
 
             // Act
-            var handlers = eventHandlers.GetEventHandlersOrDefault(eventId);
+            var handlers = eventHandlers.GetEventHandlersOrDefault(new TestEvent());
 
             // Assert
             Assert.IsNotNull(handlers);
@@ -118,16 +116,19 @@ namespace GitHubHook.Tests
         public void GetEventHandlersOrDefault_ShouldReturnRegisteredAndWildcardHandler_IfAdded()
         {
             // Arrange
-            var eventId = Guid.NewGuid().ToString("N");
-            eventHandlers.RegisterEventHandler<TestHandler>(eventId);
+            eventHandlers.RegisterEventHandler<TestHandler>();
             eventHandlers.RegisterWildcardEventHandler<TestHandler>();
 
             // Act
-            var handlers = eventHandlers.GetEventHandlersOrDefault(eventId);
+            var handlers = eventHandlers.GetEventHandlersOrDefault(new TestEvent());
 
             // Assert
             Assert.IsNotNull(handlers);
             Assert.AreEqual(2, handlers.Count());
+        }
+
+        private class TestEvent : BaseEvent
+        {
         }
 
         private class TestHandler : BaseEventHandler

--- a/GitHubHook.Tests/EventHandlersRegistryTests.cs
+++ b/GitHubHook.Tests/EventHandlersRegistryTests.cs
@@ -22,13 +22,6 @@ namespace GitHubHook.Tests
         }
 
         [TestMethod]
-        public void Ctor_ShouldNotFail()
-        {
-            // Assert
-            new EventHandlersRegistry();
-        }
-
-        [TestMethod]
         public void RegisterEventHandler_ShouldSucceed()
         {
             // Act
@@ -127,6 +120,21 @@ namespace GitHubHook.Tests
             Assert.AreEqual(2, handlers.Count());
         }
 
+        [TestMethod]
+        public void GetEventHandlersOrDefault_ShouldReturnAllValidHandlers()
+        {
+            // Arrange
+            eventHandlers.RegisterEventHandler<TestHandler>();
+            eventHandlers.RegisterEventHandler<DerivedTestHandler>();
+
+            // Act
+            var handlers = eventHandlers.GetEventHandlersOrDefault(new TestEvent());
+
+            // Assert
+            Assert.IsNotNull(handlers);
+            Assert.AreEqual(2, handlers.Count());
+        }
+
         private class TestEvent : BaseEvent
         {
         }
@@ -138,6 +146,15 @@ namespace GitHubHook.Tests
                 ILambdaContext context,
                 string deliveryId,
                 BaseEvent eventPayload)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class DerivedTestHandler : GitHubHook.Handlers.EventHandler<TestEvent>
+        {
+            public override Task<string> HandleEvent(APIGatewayProxyRequest request, ILambdaContext context, string deliveryId,
+                TestEvent eventPayload)
             {
                 throw new NotImplementedException();
             }

--- a/GitHubHook.Tests/EventPayloadFactoryTests.cs
+++ b/GitHubHook.Tests/EventPayloadFactoryTests.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Reflection;
+using System.Runtime.Serialization;
 using GitHubHook.Events;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace GitHubHook.Tests
 {
@@ -9,16 +13,29 @@ namespace GitHubHook.Tests
     {
 
         [TestMethod]
+        public void RegisterEventType_ShouldRegisterAllGitHubEventTypeAttribute()
+        {
+            // Arrange
+            var eventPayloadFactory = new EventPayloadFactory();
+
+            // Act
+            var typesRegistered = eventPayloadFactory.RegisterEventType(typeof(EditedTestActionEvent).GetTypeInfo());
+
+            // Assert
+            Assert.AreEqual(2, typesRegistered);
+        }
+
+        [TestMethod]
         public void CreateEventPayload_KnownEventType_ShouldDeserializeToTargetType()
         {
             // Arrange
-            var eventRegistry = new EventPayloadFactory();
+            var eventPayloadFactory = new EventPayloadFactory();
 
             // Act
-            var eventPayload = eventRegistry.CreateEventPayload("ping", "{}");
+            var eventPayload = eventPayloadFactory.CreateEventPayload("ping", "{}");
 
             // Assert
-            Assert.IsNotNull(eventPayload as PingEvent);
+            Assert.IsTrue(eventPayload is PingEvent);
         }
 
         [TestMethod]
@@ -28,11 +45,91 @@ namespace GitHubHook.Tests
             Assert.ThrowsException<ArgumentException>(() =>
             {
                 // Arrange
-                var eventRegistry = new EventPayloadFactory();
+                var eventPayloadFactory = new EventPayloadFactory();
 
                 // Act
-                eventRegistry.CreateEventPayload("xxx", "{}");
+                eventPayloadFactory.CreateEventPayload("xxx", "{}");
             });
+        }
+
+        [TestMethod]
+        public void CreateEventPayload_KnownActionEventType_WithoutSpecificAction_ShouldDeserializeToTargetType()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid().ToString("N");
+            var eventPayloadFactory = new EventPayloadFactory();
+            eventPayloadFactory.RegisterEventType<TestActionEvent>(eventId, null);
+
+            var payload = JsonConvert.SerializeObject(new TestActionEvent
+            {
+                Action = TestEnum.Created
+            });
+
+            // Act
+            var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+
+            // Assert
+            Assert.IsTrue(eventPayload is TestActionEvent);
+        }
+
+        [TestMethod]
+        public void CreateEventPayload_KnownActionEventType_WithSpecificAction_ShouldDeserializeToTargetType()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid().ToString("N");
+            var eventPayloadFactory = new EventPayloadFactory();
+            eventPayloadFactory.RegisterEventType<TestActionEvent>(eventId, null);
+            eventPayloadFactory.RegisterEventType<EditedTestActionEvent>(eventId, "edited");
+
+            var payload = JsonConvert.SerializeObject(new TestActionEvent
+            {
+                Action = TestEnum.Edited
+            });
+
+            // Act
+            var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+
+            // Assert
+            Assert.IsTrue(eventPayload is EditedTestActionEvent);
+        }
+
+        [TestMethod]
+        public void CreateEventPayload_KnownActionEventType_MultiWord_ShouldDeserializeToTargetType()
+        {
+            // Arrange
+            var eventId = Guid.NewGuid().ToString("N");
+            var eventPayloadFactory = new EventPayloadFactory();
+            eventPayloadFactory.RegisterEventType<TestActionEvent>(eventId, null);
+
+            var payload = JsonConvert.SerializeObject(new TestActionEvent
+            {
+                Action = TestEnum.MultiWord
+            });
+
+            // Act
+            var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+
+            // Assert
+            Assert.IsTrue(eventPayload is TestActionEvent);
+        }
+
+        [JsonConverter(typeof(StringEnumConverter), true)]
+        private enum TestEnum
+        {
+            Created,
+            Edited,
+            [EnumMember(Value = "multi_word")]
+            MultiWord
+        }
+
+        private class TestActionEvent : BaseActionEvent<TestEnum>
+        {
+        }
+
+        [Helpers.GitHubEventType("test", "edit")]
+        [Helpers.GitHubEventType("test", "update")]
+        private class EditedTestActionEvent : TestActionEvent
+        {
         }
 
     }

--- a/GitHubHook.Tests/EventPayloadFactoryTests.cs
+++ b/GitHubHook.Tests/EventPayloadFactoryTests.cs
@@ -113,6 +113,36 @@ namespace GitHubHook.Tests
             Assert.IsTrue(eventPayload is TestActionEvent);
         }
 
+        [DataTestMethod]
+        [DataRow("ping", null)]
+        [DataRow(null, "{}")]
+        public void CreateEventPayload_BadInput_ShouldThrowException(string eventId, string payload)
+        {
+            // Assert
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                // Arrange
+                var eventPayloadFactory = new EventPayloadFactory();
+
+                // Act
+                var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+            });
+        }
+
+        [TestMethod]
+        public void CreateEventPayload_BadPayload_ShouldThrowException()
+        {
+            // Assert
+            Assert.ThrowsException<ArgumentException>(() =>
+            {
+                // Arrange
+                var eventPayloadFactory = new EventPayloadFactory();
+
+                // Act
+                var eventPayload = eventPayloadFactory.CreateEventPayload("ping", string.Empty);
+            });
+        }
+
         [JsonConverter(typeof(StringEnumConverter), true)]
         private enum TestEnum
         {

--- a/GitHubHook.Tests/EventPayloadFactoryTests.cs
+++ b/GitHubHook.Tests/EventPayloadFactoryTests.cs
@@ -19,10 +19,13 @@ namespace GitHubHook.Tests
             var eventPayloadFactory = new EventPayloadFactory();
 
             // Act
-            var typesRegistered = eventPayloadFactory.RegisterEventType(typeof(EditedTestActionEvent).GetTypeInfo());
+            eventPayloadFactory.RegisterEventType(typeof(EditedTestActionEvent).GetTypeInfo());
 
             // Assert
-            Assert.AreEqual(2, typesRegistered);
+            var editedEventType = eventPayloadFactory.GetRegisteredEventType("test", "edited");
+            var updatedEventType = eventPayloadFactory.GetRegisteredEventType("test", "updated");
+            Assert.AreEqual(typeof(EditedTestActionEvent), editedEventType);
+            Assert.AreEqual(typeof(EditedTestActionEvent), updatedEventType);
         }
 
         [TestMethod]
@@ -56,9 +59,8 @@ namespace GitHubHook.Tests
         public void CreateEventPayload_KnownActionEventType_WithoutSpecificAction_ShouldDeserializeToTargetType()
         {
             // Arrange
-            var eventId = Guid.NewGuid().ToString("N");
             var eventPayloadFactory = new EventPayloadFactory();
-            eventPayloadFactory.RegisterEventType<TestActionEvent>(eventId, null);
+            eventPayloadFactory.RegisterEventType(typeof(TestActionEvent).GetTypeInfo());
 
             var payload = JsonConvert.SerializeObject(new TestActionEvent
             {
@@ -66,7 +68,7 @@ namespace GitHubHook.Tests
             });
 
             // Act
-            var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+            var eventPayload = eventPayloadFactory.CreateEventPayload("test", payload);
 
             // Assert
             Assert.IsTrue(eventPayload is TestActionEvent);
@@ -76,10 +78,9 @@ namespace GitHubHook.Tests
         public void CreateEventPayload_KnownActionEventType_WithSpecificAction_ShouldDeserializeToTargetType()
         {
             // Arrange
-            var eventId = Guid.NewGuid().ToString("N");
             var eventPayloadFactory = new EventPayloadFactory();
-            eventPayloadFactory.RegisterEventType<TestActionEvent>(eventId, null);
-            eventPayloadFactory.RegisterEventType<EditedTestActionEvent>(eventId, "edited");
+            eventPayloadFactory.RegisterEventType(typeof(TestActionEvent).GetTypeInfo());
+            eventPayloadFactory.RegisterEventType(typeof(EditedTestActionEvent).GetTypeInfo());
 
             var payload = JsonConvert.SerializeObject(new TestActionEvent
             {
@@ -87,7 +88,7 @@ namespace GitHubHook.Tests
             });
 
             // Act
-            var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+            var eventPayload = eventPayloadFactory.CreateEventPayload("test", payload);
 
             // Assert
             Assert.IsTrue(eventPayload is EditedTestActionEvent);
@@ -97,9 +98,8 @@ namespace GitHubHook.Tests
         public void CreateEventPayload_KnownActionEventType_MultiWord_ShouldDeserializeToTargetType()
         {
             // Arrange
-            var eventId = Guid.NewGuid().ToString("N");
             var eventPayloadFactory = new EventPayloadFactory();
-            eventPayloadFactory.RegisterEventType<TestActionEvent>(eventId, null);
+            eventPayloadFactory.RegisterEventType(typeof(TestActionEvent).GetTypeInfo());
 
             var payload = JsonConvert.SerializeObject(new TestActionEvent
             {
@@ -107,7 +107,7 @@ namespace GitHubHook.Tests
             });
 
             // Act
-            var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+            var eventPayload = eventPayloadFactory.CreateEventPayload("test", payload);
 
             // Assert
             Assert.IsTrue(eventPayload is TestActionEvent);
@@ -122,12 +122,13 @@ namespace GitHubHook.Tests
             MultiWord
         }
 
+        [Helpers.GitHubEventType("test")]
         private class TestActionEvent : BaseActionEvent<TestEnum>
         {
         }
 
-        [Helpers.GitHubEventType("test", "edit")]
-        [Helpers.GitHubEventType("test", "update")]
+        [Helpers.GitHubEventType("test", "edited")]
+        [Helpers.GitHubEventType("test", "updated")]
         private class EditedTestActionEvent : TestActionEvent
         {
         }

--- a/GitHubHook.Tests/EventPayloadFactoryTests.cs
+++ b/GitHubHook.Tests/EventPayloadFactoryTests.cs
@@ -125,7 +125,7 @@ namespace GitHubHook.Tests
                 var eventPayloadFactory = new EventPayloadFactory();
 
                 // Act
-                var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, payload);
+                eventPayloadFactory.CreateEventPayload(eventId, payload);
             });
         }
 
@@ -139,7 +139,7 @@ namespace GitHubHook.Tests
                 var eventPayloadFactory = new EventPayloadFactory();
 
                 // Act
-                var eventPayload = eventPayloadFactory.CreateEventPayload("ping", string.Empty);
+                eventPayloadFactory.CreateEventPayload("ping", string.Empty);
             });
         }
 

--- a/GitHubHook.Tests/Events/BaseActionEventTests.cs
+++ b/GitHubHook.Tests/Events/BaseActionEventTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using GitHubHook.Events;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GitHubHook.Tests.Events
+{
+    [TestClass]
+    public class BaseActionEventTests
+    {
+
+        [TestMethod]
+        public void ctor_WhenTIsNotEnum_ShouldThrowException()
+        {
+            // Assert
+            Assert.ThrowsException<TypeInitializationException>(() =>
+            {
+                // Act
+                new TestActionEvent();
+            });
+        }
+
+        private class TestActionEvent : BaseActionEvent<int>
+        {
+        }
+
+    }
+}

--- a/GitHubHook.Tests/LambdaHandlerTests.cs
+++ b/GitHubHook.Tests/LambdaHandlerTests.cs
@@ -162,7 +162,6 @@ namespace GitHubHook.Tests
             // Assert
             Assert.IsNotNull(response);
             Assert.AreEqual(200, response.StatusCode);
-            Assert.AreEqual($"{new DefaultHandler()}:{body}", response.Body);
         }
 
     }

--- a/GitHubHook.Tests/LambdaHandlerTests.cs
+++ b/GitHubHook.Tests/LambdaHandlerTests.cs
@@ -136,7 +136,7 @@ namespace GitHubHook.Tests
                 .Returns(authenticationResult);
 
             mockEventHandlers
-                .Setup(mock => mock.GetEventHandlersOrDefault(It.IsAny<string>()))
+                .Setup(mock => mock.GetEventHandlersOrDefault(It.IsAny<BaseEvent>()))
                 .Returns(new List<BaseEventHandler>
                 {
                     new DefaultHandler()

--- a/GitHubHook.Tests/TestPayloads/PingPayloadSecurity.txt
+++ b/GitHubHook.Tests/TestPayloads/PingPayloadSecurity.txt
@@ -1,2 +1,0 @@
-﻿A3UB12ga#%TMp%asL5or@Nb2%l8m1h8*vja5^Pj3xc^&%cdYcQo$WNDzfeX*HhUt^SzuDM!g5*RiEEugcb12^u@kh2pdmUtDhaFC
-sha1=eb4acec0ce7e63f015dfac6681aab94b3ec028ed

--- a/GitHubHook/DeliveryResult.cs
+++ b/GitHubHook/DeliveryResult.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using GitHubHook.Helpers;
+
+namespace GitHubHook
+{
+    internal class DeliveryResult : SnakeCaseNamedObject
+    {
+        public DeliveryResult()
+        {
+            EventHandlerResults = new List<string>();
+        }
+
+        public void SetEventPayloadType(Type type)
+        {
+            EventPayloadType = $"Payload: {type.Name}";
+        }
+
+        public string EventPayloadType { get; private set; }
+        public List<string> EventHandlerResults { get; }
+    }
+}

--- a/GitHubHook/EventPayloadFactory.cs
+++ b/GitHubHook/EventPayloadFactory.cs
@@ -69,6 +69,16 @@ namespace GitHubHook
 
         internal BaseEvent CreateEventPayloadInternal(string eventId, string action, string payload)
         {
+            if (string.IsNullOrWhiteSpace(eventId))
+            {
+                throw new ArgumentNullException(nameof(eventId));
+            }
+
+            if (payload == null)
+            {
+                throw new ArgumentNullException(nameof(payload));
+            }
+
             var eventType = GetRegisteredEventType(eventId, action);
 
             if (eventType == null)

--- a/GitHubHook/Events/BaseActionEvent.cs
+++ b/GitHubHook/Events/BaseActionEvent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace GitHubHook.Events
+{
+    public abstract class BaseActionEvent<T> : BaseEvent, IActionEvent where T : struct
+    {
+        static BaseActionEvent()
+        {
+            if (!typeof(T).GetTypeInfo().IsEnum)
+            {
+                throw new ArgumentException("Generic type parameter T is not a System.Enum");
+            }
+        }
+
+        public T Action { get; set; }
+
+        public string GetActionValue()
+        {
+            // This isn't the best way but until we have a snake case converter, this will do.
+            return JsonConvert.SerializeObject(Action).Trim('"');
+        }
+    }
+}

--- a/GitHubHook/Events/IActionEvent.cs
+++ b/GitHubHook/Events/IActionEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace GitHubHook.Events
+{
+    public interface IActionEvent
+    {
+        string GetActionValue();
+    }
+}

--- a/GitHubHook/Handlers/BaseEventHandler.cs
+++ b/GitHubHook/Handlers/BaseEventHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
 using GitHubHook.Events;
@@ -12,5 +13,10 @@ namespace GitHubHook.Handlers
             ILambdaContext context,
             string deliveryId,
             BaseEvent eventPayload);
+
+        public virtual bool CanHandleEvent(Type type)
+        {
+            return true;
+        }
     }
 }

--- a/GitHubHook/Handlers/EventHandler.cs
+++ b/GitHubHook/Handlers/EventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
@@ -30,6 +31,11 @@ namespace GitHubHook.Handlers
                     $"EventHandler expects payload of type '{typeof(T)}', received type '{eventPayload.GetType()}'",
                     nameof(eventPayload));
             }
+        }
+
+        public override bool CanHandleEvent(Type type)
+        {
+            return typeof(T).IsAssignableFrom(type);
         }
     }
 }

--- a/GitHubHook/Helpers/GitHubEventTypeAttribute.cs
+++ b/GitHubHook/Helpers/GitHubEventTypeAttribute.cs
@@ -2,14 +2,20 @@
 
 namespace GitHubHook.Helpers
 {
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
     internal class GitHubEventTypeAttribute : Attribute
     {
         public string EventId { get; set; }
+        public string Action { get; set; }
 
-        public GitHubEventTypeAttribute(string eventId)
+        public GitHubEventTypeAttribute(string eventId) : this(eventId, null)
+        {
+        }
+
+        public GitHubEventTypeAttribute(string eventId, string action)
         {
             EventId = eventId;
+            Action = action;
         }
     }
 }

--- a/GitHubHook/IEventHandlersRegistry.cs
+++ b/GitHubHook/IEventHandlersRegistry.cs
@@ -1,14 +1,15 @@
 ﻿using System.Collections.Generic;
+using GitHubHook.Events;
 using GitHubHook.Handlers;
 
 namespace GitHubHook
 {
     public interface IEventHandlersRegistry
     {
-        void RegisterEventHandler<T>(string eventId) where T : BaseEventHandler, new();
-        void RegisterEventHandler<T>(string eventId, T handler) where T : BaseEventHandler;
+        void RegisterEventHandler<T>() where T : BaseEventHandler, new();
+        void RegisterEventHandler<T>(T handler) where T : BaseEventHandler;
         void RegisterWildcardEventHandler<T>() where T : BaseEventHandler, new();
         void RegisterWildcardEventHandler<T>(T handler) where T : BaseEventHandler;
-        IEnumerable<BaseEventHandler> GetEventHandlersOrDefault(string eventId);
+        IEnumerable<BaseEventHandler> GetEventHandlersOrDefault(BaseEvent eventPayload);
     }
 }

--- a/GitHubHook/IEventPayloadFactory.cs
+++ b/GitHubHook/IEventPayloadFactory.cs
@@ -5,6 +5,5 @@ namespace GitHubHook
     public interface IEventPayloadFactory
     {
         BaseEvent CreateEventPayload(string eventId, string payload);
-        void RegisterEventType<T>(string eventId, string action = null);
     }
 }

--- a/GitHubHook/IEventPayloadFactory.cs
+++ b/GitHubHook/IEventPayloadFactory.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using GitHubHook.Events;
+﻿using GitHubHook.Events;
 
 namespace GitHubHook
 {
     public interface IEventPayloadFactory
     {
         BaseEvent CreateEventPayload(string eventId, string payload);
-        void RegisterEventType(string eventId, Type eventType);
+        void RegisterEventType<T>(string eventId, string action = null);
     }
 }

--- a/GitHubHook/LambdaHandler.cs
+++ b/GitHubHook/LambdaHandler.cs
@@ -24,8 +24,6 @@ namespace GitHubHook
             this.authentication = authentication;
             this.eventHandlers = eventHandlers;
             this.eventPayloadFactory = eventPayloadFactory;
-
-            // TODO: do we need validation for mismatch between event handlers and payload factories?
         }
 
         public async Task<APIGatewayProxyResponse> Handle(APIGatewayProxyRequest request, ILambdaContext context)
@@ -87,8 +85,8 @@ namespace GitHubHook
 
             context.Logger.Log($"DEBUG: Processing delivery {deliveryId} ({eventId})");
 
-            var handlers = eventHandlers.GetEventHandlersOrDefault(eventId);
             var eventPayload = eventPayloadFactory.CreateEventPayload(eventId, request.Body);
+            var handlers = eventHandlers.GetEventHandlersOrDefault(eventPayload);
 
             var resultBuilder = new StringBuilder();
             foreach (var handler in handlers)

--- a/GitHubHook/LambdaHandler.cs
+++ b/GitHubHook/LambdaHandler.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Text;
 using System.Threading.Tasks;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace GitHubHook
 {


### PR DESCRIPTION
`EventHandlerRegistry` now registers handlers and determine eventId (and the new action) values from the handled type's `GitHubEventTypeAttribute` information.

`EventHandlerRegistry` will now return all handler that's compatible to the payload type. This means there will never be mismatch between handler's eventId registration and the EventPayloadFactory created event type.

`EventPayloadFactory` can no longer register event types outside of framework. Please create a PR for additions/modifications to the event models.

Action-specific event models will be added via a separate PR.