### PR TITLE
Removed wildcard event handler registration

### DIFF
--- a/GitHubHook/EventHandlersRegistry.cs
+++ b/GitHubHook/EventHandlersRegistry.cs
@@ -8,12 +8,10 @@ namespace GitHubHook
     {
 
         internal readonly List<BaseEventHandler> eventHandlers;
-        internal readonly List<BaseEventHandler> wildcardEventHandlers;
 
         public EventHandlersRegistry()
         {
             eventHandlers = new List<BaseEventHandler>();
-            wildcardEventHandlers = new List<BaseEventHandler>();
         }
 
         public void RegisterEventHandler<T>()
@@ -26,18 +24,6 @@ namespace GitHubHook
             where T : BaseEventHandler
         {
             eventHandlers.Add(handler);
-        }
-
-        public void RegisterWildcardEventHandler<T>()
-            where T : BaseEventHandler, new()
-        {
-            RegisterWildcardEventHandler(new T());
-        }
-
-        public void RegisterWildcardEventHandler<T>(T handler)
-            where T : BaseEventHandler
-        {
-            wildcardEventHandlers.Add(handler);
         }
 
         public IEnumerable<BaseEventHandler> GetEventHandlersOrDefault(BaseEvent eventPayload)
@@ -53,8 +39,6 @@ namespace GitHubHook
                 }
                 
             }
-
-            handlers.AddRange(wildcardEventHandlers);
 
             if (handlers.Count == 0)
             {

--- a/GitHubHook/IEventHandlersRegistry.cs
+++ b/GitHubHook/IEventHandlersRegistry.cs
@@ -8,8 +8,6 @@ namespace GitHubHook
     {
         void RegisterEventHandler<T>() where T : BaseEventHandler, new();
         void RegisterEventHandler<T>(T handler) where T : BaseEventHandler;
-        void RegisterWildcardEventHandler<T>() where T : BaseEventHandler, new();
-        void RegisterWildcardEventHandler<T>(T handler) where T : BaseEventHandler;
         IEnumerable<BaseEventHandler> GetEventHandlersOrDefault(BaseEvent eventPayload);
     }
 }

--- a/samples/GitHubHook.S3Dump/Function.cs
+++ b/samples/GitHubHook.S3Dump/Function.cs
@@ -21,7 +21,7 @@ namespace GitHubHook.S3Dump
         public Function()
         {
             var eventHandlers = new EventHandlersRegistry();
-            eventHandlers.RegisterWildcardEventHandler<AnyToS3Handler>();
+            eventHandlers.RegisterEventHandler<AnyToS3Handler>();
 
             lambdaHandler = new LambdaHandler(
                 new Authentication(),


### PR DESCRIPTION
Wildcard registration has been superseded by registering implementation of `BaseEventHandler`. It will match and handle all event types. Removing wildcard handlers will eliminate mismatched handler because everything (except the fallback DefaultHandler) will go through `CanHandleEvent` check.